### PR TITLE
Add support for "native" inkscape files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ More samples are available in the *[samples](http://htmlpreview.github.io/?https
 - you keep the nodes' hierarchy tree, not the pain of placing sprites in containers, etc,
 - it will render as native svg as you designed it
 
+# Preparing your SVG files
+
+Your SVG files must not use groups with their own `translate`
+attributes. i.e. all coordinates in paths etc. must be global.
+
+In Inkscape, the [apply transforms](https://github.com/Klowner/inkscape-applytransforms)
+plugin is useful to remove these.
+
 ## id query strings
 
 You can add a query string to your node's ids like #my-id?key1=value1&key2=value2. Valid keys are for now:

--- a/lib/phantom/makeTree.js
+++ b/lib/phantom/makeTree.js
@@ -68,10 +68,33 @@ window.makeTree = (function() {
 		
 		for (var i = 0; i < node.childNodes.length; i++) {
 			var child = node.childNodes[i];
-			var child_txt = asText(child);
+
+			if (child.nodeName.substr(0,8) == 'sodipodi' ) continue;//skip inkscape specific stuff
 			if (child.nodeName.charAt(0) == '#') continue;
-			
+
 			var id_data = parseID(child.id);
+
+			if (!id_data.origin) {
+				// if origin not set in ID, look for inkscape attributes
+				var oy = child.attributes['inkscape:transform-center-y'];
+				var ox = child.attributes['inkscape:transform-center-x'];
+				if (ox && oy) {
+					id_data.origin = 'c+'+ox.value+',c+'+-parseFloat(oy.value);
+				}
+
+			}
+
+			// then remove all inkscape/sodipodi attributes
+			for (var j = child.attributes.length-1 ; j>=0 ; j--) {
+				var a = child.attributes[j];
+				if (a.name && (a.name.substr(0,8) == 'inkscape' || a.name.substr(0,8) == 'sodipodi')) {
+					child.attributes.removeNamedItemNS(a.namespaceURI, a.localName);
+				}
+			}
+
+
+			var child_txt = asText(child);
+
 			var tag = child.nodeName.toLowerCase();
 			if (has_children.indexOf(tag) >= 0) {
 				// Default for direct children


### PR DESCRIPTION
Inkscape add a bunch of extra attributes, elements, these would
previously confuse pixi-svg-loader. This adds code to strip while loading them.

This is more useful than saving as  `plain SVG` or `optimized SVG` in Inkscape, since then we would lose the inkscape attributes too early, now we can also set the origin automatically from the inkscape specific attributes if not specified in the id query parameters.
